### PR TITLE
Adding Google Auth and Https support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ project/plugins/project/
 *assets/javascripts/lib/
 *assets/stylesheets/lib/
 
+cloudformation.json
 node_modules
 public

--- a/app/Global.scala
+++ b/app/Global.scala
@@ -3,6 +3,7 @@ import actions.CommonActions
 import play.api.GlobalSettings
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc._
+import play.api.routing.Router.Routes
 
 import scala.concurrent.Future
 
@@ -23,7 +24,7 @@ class AuthorizedFilter(actionNames: Seq[String]) extends Filter with CommonActio
   }
 
   private def authorizationNotRequired(request: RequestHeader) = {
-    val actionInvoked: String = request.tags.getOrElse(play.api.Routes.ROUTE_ACTION_METHOD, "")
+    val actionInvoked: String = request.tags.getOrElse(play.api.routing.Router.Tags.RouteActionMethod, "")
     actionNames.contains(actionInvoked)
   }
 }
@@ -47,7 +48,7 @@ object HTTPSRedirectFilter extends Filter {
   }
 }
 
-object Global extends WithFilters(HTTPSRedirectFilter, AuthorizedFilter("login", "loginAction", "oauth2Callback", "health")) with GlobalSettings {
+object Global extends WithFilters(HTTPSRedirectFilter, AuthorizedFilter("login", "loginAction", "oauth2Callback", "healthcheck")) with GlobalSettings {
 
   override def onStart(application: play.api.Application): Unit = {}
 

--- a/app/Global.scala
+++ b/app/Global.scala
@@ -1,0 +1,56 @@
+
+import actions.CommonActions
+import play.api.GlobalSettings
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.mvc._
+
+import scala.concurrent.Future
+
+object AuthorizedFilter {
+  def apply(actionNames: String*) = new AuthorizedFilter(actionNames)
+}
+
+class AuthorizedFilter(actionNames: Seq[String]) extends Filter with CommonActions {
+
+  def apply(next: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] = {
+    if(authorizationNotRequired(request)) {
+      next(request)
+    }
+    else {
+      val action = googleAuthenticatedStaffAction.async(req => next(request))
+      action.apply(Request[AnyContent](request, AnyContentAsEmpty))
+    }
+  }
+
+  private def authorizationNotRequired(request: RequestHeader) = {
+    val actionInvoked: String = request.tags.getOrElse(play.api.Routes.ROUTE_ACTION_METHOD, "")
+    actionNames.contains(actionInvoked)
+  }
+}
+
+object HTTPSRedirectFilter extends Filter {
+
+  def apply(nextFilter: (RequestHeader) => Future[Result])(requestHeader: RequestHeader): Future[Result] = {
+    //play uses lower case headers.
+    requestHeader.headers.get("x-forwarded-proto") match {
+      case Some(header) => {
+        if ("https" == header) {
+          nextFilter(requestHeader).map { result =>
+            result.withHeaders(("Strict-Transport-Security", "max-age=31536000"))
+          }
+        } else {
+          Future.successful(Results.Redirect("https://" + requestHeader.host + requestHeader.uri, 301))
+        }
+      }
+      case None => nextFilter(requestHeader)
+    }
+  }
+}
+
+object Global extends WithFilters(HTTPSRedirectFilter, AuthorizedFilter("login", "loginAction", "oauth2Callback", "health")) with GlobalSettings {
+
+  override def onStart(application: play.api.Application): Unit = {}
+
+  override def onStop(application: play.api.Application) {}
+
+}

--- a/app/actions/CommonActions.scala
+++ b/app/actions/CommonActions.scala
@@ -1,0 +1,35 @@
+package actions
+
+import configuration.Config
+import controllers.routes
+import play.api.mvc._
+import com.gu.googleauth
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+trait CommonActions {
+
+  import CommonActions._
+  val noCacheAction = resultModifier(noCache)
+
+  val googleAuthAction = OAuthActions.AuthAction
+
+  val googleAuthenticatedStaffAction = noCacheAction andThen googleAuthAction
+}
+
+object CommonActions {
+  def resultModifier(f: Result => Result) = new ActionBuilder[Request] {
+    def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = block(request).map(f)
+  }
+
+  def noCache(result: Result): Result = result.withHeaders("Cache-Control" -> "no-cache, private", "Pragma" -> "no-cache")
+}
+
+trait OAuthActions extends com.gu.googleauth.Actions {
+  val authConfig = Config.googleAuthConfig
+
+  val loginTarget = routes.OAuth.loginAction()
+}
+
+object OAuthActions extends OAuthActions

--- a/app/actions/Functions.scala
+++ b/app/actions/Functions.scala
@@ -1,0 +1,18 @@
+package actions
+
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.mvc._
+import scala.concurrent.Future
+
+/**
+ * These ActionFunctions serve as components that can be composed to build the
+ * larger, more-generally useful pipelines in 'CommonActions'.
+ *
+ * https://www.playframework.com/documentation/2.3.x/ScalaActionsComposition
+ */
+object Functions {
+
+  def resultModifier(f: Result => Result) = new ActionBuilder[Request] {
+    def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = block(request).map(f)
+  }
+}

--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -1,0 +1,26 @@
+package configuration
+
+import com.gu.googleauth.GoogleAuthConfig
+import com.typesafe.config.ConfigFactory
+import play.api.Logger
+
+object Config {
+  val logger = Logger(this.getClass())
+
+  val config = ConfigFactory.load()
+
+  val GuardianGoogleAppsDomain = "guardian.co.uk"
+
+  val googleAuthConfig = {
+    val con = ConfigFactory.load().getConfig("google.oauth")
+    GoogleAuthConfig(
+      con.getString("client.id"),
+      con.getString("client.secret"),
+      con.getString("callback"),
+      Some(GuardianGoogleAppsDomain) // Google App domain to restrict login
+    )
+  }
+
+  val staffAuthorisedEmailGroups = config.getString("staff.authorised.emails.groups").split(",").map(group => s"$group@$GuardianGoogleAppsDomain").toSet
+
+}

--- a/app/controllers/OAuth.scala
+++ b/app/controllers/OAuth.scala
@@ -1,0 +1,73 @@
+package controllers
+
+import actions.OAuthActions
+import actions.CommonActions
+import com.gu.googleauth.{GoogleAuth, UserIdentity}
+import configuration.Config
+import lib.TimeFilter
+import models.FlashMessage
+import org.joda.time.DateTime
+import play.api.Play.current
+import play.api.libs.json.Json
+import play.api.mvc._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class OAuth extends Controller with OAuthActions with CommonActions {
+
+  val ANTI_FORGERY_KEY = "antiForgeryToken"
+
+  def login = noCacheAction { request =>
+    val flashMsgOpt = request.flash.get("error").map(FlashMessage.error)
+    Ok(views.html.unauthorised(flashMsgOpt, None, ""))
+  }
+
+
+  /**
+   * Redirect to Google with anti forgery token (that we keep in session storage - note that flashing is NOT secure)
+   */
+  def loginAction = Action.async { implicit request =>
+    val antiForgeryToken = GoogleAuth.generateAntiForgeryToken()
+    GoogleAuth.redirectToGoogle(Config.googleAuthConfig, antiForgeryToken)
+      .map{ redirect =>
+        redirect.withSession(request.session + (ANTI_FORGERY_KEY -> antiForgeryToken))
+      }
+  }
+
+  /**
+   * User comes back from Google.
+   * We must ensure we have the anti forgery token from the loginAction call and pass this into a verification call which
+   * will return a Future[UserIdentity] if the authentication is successful. If unsuccessful then the Future will fail.
+   */
+  def oauth2Callback = Action.async { implicit request =>
+    val session = request.session
+    session.get(ANTI_FORGERY_KEY) match {
+      case None =>
+        Future.successful(Redirect(routes.OAuth.login()).flashing("error" -> "Anti forgery token missing in session"))
+      case Some(token) =>
+        GoogleAuth.validatedUserIdentity(Config.googleAuthConfig, token).map { identity =>
+          // We store the URL a user was trying to get to in the LOGIN_ORIGIN_KEY in AuthAction
+          // Redirect a user back there now if it exists
+          val redirect = session.get(LOGIN_ORIGIN_KEY) match {
+            case Some(url) => Redirect(url)
+            case None => Redirect(routes.Application.index(TimeFilter(new DateTime().minusDays(7), new DateTime())))
+          }
+          // Store the JSON representation of the identity in the session - this is checked by AuthAction later
+          redirect.withSession {
+            session + (UserIdentity.KEY -> Json.toJson(identity).toString) - ANTI_FORGERY_KEY - LOGIN_ORIGIN_KEY
+          }
+
+        } recover {
+          case t =>
+            // you might want to record login failures here - we just redirect to the login page
+            redirectWithError(session, s"Login failure: ${t.toString}")
+        }
+    }
+  }
+
+  private def redirectWithError(session: Session, errorMessage: String) =
+    Redirect(routes.OAuth.login())
+      .withSession(session - ANTI_FORGERY_KEY)
+      .flashing("error" -> errorMessage)
+}

--- a/app/models/FlashMessage.scala
+++ b/app/models/FlashMessage.scala
@@ -1,0 +1,8 @@
+package models
+
+abstract case class FlashMessage(level: String, message: String)
+
+object FlashMessage {
+  def error(message: String) = new FlashMessage("error", message) {}
+  def success(message: String) = new FlashMessage("success", message) {}
+}

--- a/app/models/package.scala
+++ b/app/models/package.scala
@@ -1,3 +1,4 @@
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
@@ -9,8 +10,12 @@ import play.api.libs.json.{Format, Json}
 import scala.util.Try
 
 package object models {
-  val dynamoDbClient: AmazonDynamoDBAsyncClient =
+  val dynamoDbClient: AmazonDynamoDBAsyncClient = if (play.api.Play.isDev(play.api.Play.current)) {
     new AmazonDynamoDBAsyncClient(new ProfileCredentialsProvider("frontend")).withRegion(Regions.EU_WEST_1)
+  } else {
+    new AmazonDynamoDBAsyncClient().withRegion(Regions.EU_WEST_1)
+  }
+
 
   implicit class RichAttributeMap(map: Map[String, AttributeValue]) {
     def getString(k: String): Option[String] =

--- a/app/views/unauthorised.scala.html
+++ b/app/views/unauthorised.scala.html
@@ -1,0 +1,10 @@
+@(flashMessageOpt: Option[models.FlashMessage], errorTemplateOpt: Option[String] = None, staffEmail: String = "")
+
+@main(title = "Unauthorised Staff") {
+
+    <main class="page-content l-constrained" role="main">
+
+        <h1>Sorry, we are having problems authenticating your email address</h1>
+
+    </main>
+}

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ libraryDependencies ++= Seq(
   cache,
   ws,
   "com.amazonaws" % "aws-java-sdk" % "1.10.39",
+  "com.gu" %% "play-googleauth" % "0.3.1",
   specs2 % Test
 )
 

--- a/cloudformation.sh
+++ b/cloudformation.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+npm run cloudformation --loglevel silent > cloudformation.json

--- a/cloudformation/cloudformation.template.yaml
+++ b/cloudformation/cloudformation.template.yaml
@@ -105,7 +105,7 @@ Resources:
   InstanceSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: trigr instance
+      GroupDescription: Email reporting instance
       VpcId: {Ref: VPC}
       SecurityGroupIngress:
       - {IpProtocol: tcp, FromPort: 9000, ToPort: 9000, SourceSecurityGroupId: {Ref: ELBSecurityGroup} }

--- a/cloudformation/cloudformation.template.yaml
+++ b/cloudformation/cloudformation.template.yaml
@@ -16,7 +16,7 @@ Parameters:
   ImageId:
     Description: AMI id
     Type: AWS::EC2::Image::Id
-    Default: "ami-7463cd07"
+    Default: "ami-8b60cef8"
 
 Resources:
   Role:

--- a/cloudformation/cloudformation.template.yaml
+++ b/cloudformation/cloudformation.template.yaml
@@ -41,6 +41,9 @@ Resources:
         - Action: ["EC2:Describe*"]
           Effect: "Allow"
           Resource: "*"
+        - Action: ["S3:getObject"]
+          Effect: Allow
+          Resource: "arn:aws:s3:::frontend-email-reporting-dist/*"
       Roles:
       - {Ref: Role}
   InstanceProfile:
@@ -97,6 +100,7 @@ Resources:
       UserData:
         Fn::Base64: |
           #!/bin/bash -ev
+          aws s3 cp s3://frontend-email-reporting-dist/frontend/PROD/email-reporting/email-reporting-keys.conf /etc/gu/email-reporting-keys.conf
           /opt/features/native-packager/install.sh -b frontend-email-reporting-dist -s -t tgz
   InstanceSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/cloudformation/cloudformation.template.yaml
+++ b/cloudformation/cloudformation.template.yaml
@@ -16,7 +16,7 @@ Parameters:
   ImageId:
     Description: AMI id
     Type: AWS::EC2::Image::Id
-    Default: "ami-2ce4465f"
+    Default: "ami-7463cd07"
 
 Resources:
   Role:

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -16,4 +16,6 @@ logger.application=DEBUG
 
 #### Import private keys
 
-include file("/etc/gu/email-reporting.conf")
+staff.authorised.emails.groups="guardian.co.uk"
+
+include file("/etc/gu/email-reporting-keys.conf")

--- a/conf/routes
+++ b/conf/routes
@@ -9,3 +9,12 @@ GET        /stats/:id           controllers.Application.stats(id: Int, t: TimeFi
 # Map static resources from the /public folder to the /assets URL path
 GET        /assets/*file        controllers.Assets.versioned(path="/public", file: Asset)
 GET        /healthcheck         controllers.Application.healthcheck
+
+
+#############
+# Auth
+#############
+
+GET        /login               controllers.OAuth.login
+GET        /loginAction         controllers.OAuth.loginAction
+GET        /oauth2callback      controllers.OAuth.oauth2Callback


### PR DESCRIPTION
This PR
- Adds Google Auth to all routes apart from `healthcheck` and login related routes
- Redirects all `http` traffic to `https`
- Only loads local config using aws `ProfileCredentialsProvider` 
