### PR TITLE
Add GuardianTodayUsFinalNew

### DIFF
--- a/collector/config.py
+++ b/collector/config.py
@@ -7,6 +7,7 @@ GuTodayUk = 111
 GuTodayUs = 1933
 GuardianTodayUsFinalA = 16125
 GuardianTodayUsFinalB = 16126
+GuardianTodayUsFinalNew = 16127
 
 
 # AU Send Definitions
@@ -18,5 +19,6 @@ SEND_DEFINITIONS = [
     GuTodayUs,
     GuardianTodayUsFinalA,
     GuardianTodayUsFinalB,
+    GuardianTodayUsFinalNew,
     GuTodayAu
 ]


### PR DESCRIPTION
This adds the missing email send definition that is used for `US` send outs.

@dominickendrick 
